### PR TITLE
updated public storybook link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ More details about the project can be found on this <a href="https://github.com/
 
 ## StoryBook
 
-The storybook with all available atomic design levels can be seen https://prashantsihag03.github.io/yourchatsV2-fe/
+The storybook with all available atomic design levels can be seen https://yourchatsv2-fe-storybook.netlify.app/?path=/story/introduction--page
 
 ## Start App Locally
 


### PR DESCRIPTION
The public storybook has moved to Netlify from github pages. This PR updates the public storybook link in README file.